### PR TITLE
Constify fix for rtnl_link_ops

### DIFF
--- a/kernel-patch/kernel-6.0.0-eoip.patch
+++ b/kernel-patch/kernel-6.0.0-eoip.patch
@@ -56,7 +56,7 @@
 +#include <net/ip6_route.h>
 +#endif
 +
-+static struct rtnl_link_ops eoip_ops __read_mostly;
++static struct rtnl_link_ops eoip_ops __read_only;
 +static int eoip_tunnel_bind_dev(struct net_device *dev);
 +static void eoip_setup(struct net_device *dev);
 +
@@ -856,7 +856,7 @@
 +	[IFLA_GRE_TOS]		= { .type = NLA_U8 },
 +};
 +
-+static struct rtnl_link_ops eoip_ops __read_mostly = {
++static struct rtnl_link_ops eoip_ops __read_only = {
 +	.kind		= "eoip",
 +	.maxtype	= IFLA_GRE_MAX,
 +	.policy		= eoip_policy,

--- a/kernel-patch/kernel-6.1.0-eoip.patch
+++ b/kernel-patch/kernel-6.1.0-eoip.patch
@@ -56,7 +56,7 @@
 +#include <net/ip6_route.h>
 +#endif
 +
-+static struct rtnl_link_ops eoip_ops __read_mostly;
++static struct rtnl_link_ops eoip_ops __read_only;
 +static int eoip_tunnel_bind_dev(struct net_device *dev);
 +static void eoip_setup(struct net_device *dev);
 +
@@ -856,7 +856,7 @@
 +	[IFLA_GRE_TOS]		= { .type = NLA_U8 },
 +};
 +
-+static struct rtnl_link_ops eoip_ops __read_mostly = {
++static struct rtnl_link_ops eoip_ops __read_only = {
 +	.kind		= "eoip",
 +	.maxtype	= IFLA_GRE_MAX,
 +	.policy		= eoip_policy,


### PR DESCRIPTION
In the real CONSTIFY plugin (not the watered-down upstream port), the `__read_mostly` attribute on `rtnl_link_ops` causes
```sh
net/ipv4/eoip.c:890:29: error: constified variable 'eoip_ops'
 placed into writable section ".data..read_mostly"
```

Since "Fri Oct 7 12:36:38 2016," i've carried a patch in my kernels to remedy this concern by altering the struct to be `__read_only`.

This problem will someday arise in upstream Linux when they finally enable constification of all structs containing pointers.

This commit seeks to preempt the concern in EoIP code proper such that if and when Linux decides to improve their plugin coverage to match the original implementation, this won't cause problems for the users. Concurrently, this should permit EoIP users who are also Grsecurity (well, PaX) users to build and run EoIP without having to patch atop their EoIP patch.

Testing:
  \>6y of production use on Grsecurity-hardened systems

Notes:
  This is not a fix for a current bug under common usage by Linux consumers. As such, its by no means critical to merge. If it is deemed non-viable for commit to the master branch, it may still be of use to others in the PR archive or a separate tag to inform on how to remedy the issue.